### PR TITLE
fix: :bug: Fix hide/show text depends on external-link url

### DIFF
--- a/src/components/ExitModal.astro
+++ b/src/components/ExitModal.astro
@@ -34,20 +34,21 @@
 
 <script>
   import { Fancybox } from "@fancyapps/ui";
-  const linksWithHideContent = [
-    'https://alexionaccessnavigator.com/',
-    'https://strensiq.com/',
-    'https://alexion.com/',
-    'https://alexion.com/Legal#legalstatement',
-    'https://alexion.com/Legal#privacynotice',
-    'https://alexion.com/Legal#termsofuse',
-    'https://alexion.com/contact-alexion',
-    'https://alexiononesource.com/'
-  ]
 
   const externalLinks = document.querySelectorAll(
     'a[target="_blank"]:not(.document-link)'
   );
+
+  const hideContentLinks = [
+    "https://alexionaccessnavigator.com/",
+    "https://strensiq.com/",
+    "https://alexion.com/",
+    "https://alexion.com/Legal#legalstatement",
+    "https://alexion.com/Legal#privacynotice",
+    "https://alexion.com/Legal#termsofuse",
+    "https://alexion.com/contact-alexion",
+    "https://alexiononesource.com/",
+  ];
 
   if (externalLinks && externalLinks.length > 0) {
     externalLinks.forEach((link) => {
@@ -62,15 +63,18 @@
         const continueButton = modal.querySelector(".modal--continue");
         const stayButton = modal.querySelector(".modal--stay");
         const modalClose = modal.querySelector(".modal__close");
-        const modalText = modal.querySelector(".modal__text")
+        const modalText = modal.querySelector(".modal__text");
 
-        if (linksWithHideContent.indexOf(href) !== -1) {
-          modalText.style.setProperty('display', 'none')
+        if (hideContentLinks.indexOf(href) !== -1) {
+          modalText.style.setProperty("display", "none");
 
-          if ((href === 'https://alexion.com/Legal#privacynotice' || href === 'https://alexion.com/Legal#termsofuse') && !e.target.classList.contains('footer__nav_menu_item_link')) {
-            modalText.style.removeProperty('display')
+          if (
+            (href === "https://alexion.com/Legal#privacynotice" ||
+              href === "https://alexion.com/Legal#termsofuse") &&
+            !e.target.classList.contains("footer__nav_menu_item_link")
+          ) {
+            modalText.style.removeProperty("display");
           }
-
         }
 
         continueButton.setAttribute("href", href);
@@ -87,8 +91,8 @@
 
         if (continueLink) {
           const secondaryLink = "https://alexion.com/Legal#privacynotice";
-          continueLink.setAttribute('href', secondaryLink)
-          continueLink.setAttribute('target', '_blank')
+          continueLink.setAttribute("href", secondaryLink);
+          continueLink.setAttribute("target", "_blank");
           continueLink.addEventListener("click", handleClickContinueLink);
         }
 
@@ -102,23 +106,26 @@
           dragToClose: false,
           on: {
             close: () => {
-              continueButton.removeEventListener('click', handleClickContinue)
-              if(continueLink) {
-                continueLink.removeEventListener("click", handleClickContinueLink)
+              continueButton.removeEventListener("click", handleClickContinue);
+              if (continueLink) {
+                continueLink.removeEventListener(
+                  "click",
+                  handleClickContinueLink
+                );
               }
-              modalText.style.removeProperty('display')
+              modalText.style.removeProperty("display");
             },
           },
         });
 
-        function handleClickContinue (event) {
+        function handleClickContinue(event) {
           setTimeout(() => {
             instance.close();
           }, 500);
           return;
         }
 
-        function handleClickContinueLink (event) {
+        function handleClickContinueLink(event) {
           setTimeout(() => {
             instance.close();
           }, 500);

--- a/src/components/ExitModal.astro
+++ b/src/components/ExitModal.astro
@@ -66,6 +66,11 @@
 
         if (linksWithHideContent.indexOf(href) !== -1) {
           modalText.style.setProperty('display', 'none')
+
+          if ((href === 'https://alexion.com/Legal#privacynotice' || href === 'https://alexion.com/Legal#termsofuse') && !e.target.classList.contains('footer__nav_menu_item_link')) {
+            modalText.style.removeProperty('display')
+          }
+
         }
 
         continueButton.setAttribute("href", href);

--- a/src/components/ExitModal.astro
+++ b/src/components/ExitModal.astro
@@ -20,12 +20,13 @@
       </div>
 
       <div class="modal__text">
-        <!-- <p>
+        <p>
           You are now leaving strensiq-hcp.com, a website provided by Alexion
           Pharmaceuticals, Inc. This link will take you to a different site that
           is owned and operated by an independent third party to which this <br
           />
-          <a class="modal__text-link">Privacy Notice</a> does not apply. -->
+          <a class="modal__text-link">Privacy Notice</a> does not apply.
+        </p>
       </div>
     </div>
   </div>
@@ -33,6 +34,16 @@
 
 <script>
   import { Fancybox } from "@fancyapps/ui";
+  const linksWithHideContent = [
+    'https://alexionaccessnavigator.com/',
+    'https://strensiq.com/',
+    'https://alexion.com/',
+    'https://alexion.com/Legal#legalstatement',
+    'https://alexion.com/Legal#privacynotice',
+    'https://alexion.com/Legal#termsofuse',
+    'https://alexion.com/contact-alexion',
+    'https://alexiononesource.com/'
+  ]
 
   const externalLinks = document.querySelectorAll(
     'a[target="_blank"]:not(.document-link)'
@@ -51,6 +62,11 @@
         const continueButton = modal.querySelector(".modal--continue");
         const stayButton = modal.querySelector(".modal--stay");
         const modalClose = modal.querySelector(".modal__close");
+        const modalText = modal.querySelector(".modal__text")
+
+        if (linksWithHideContent.indexOf(href) !== -1) {
+          modalText.style.setProperty('display', 'none')
+        }
 
         continueButton.setAttribute("href", href);
         continueButton.setAttribute("target", "_blank");
@@ -65,14 +81,10 @@
         continueButton.addEventListener("click", handleClickContinue);
 
         if (continueLink) {
-          continueLink.addEventListener("click", () => {
-            const secondaryLink = "https://alexion.com/Legal#privacynotice";
-
-            setTimeout(() => {
-              window.open(secondaryLink, "_blank");
-              instance.close();
-            }, 500);
-          });
+          const secondaryLink = "https://alexion.com/Legal#privacynotice";
+          continueLink.setAttribute('href', secondaryLink)
+          continueLink.setAttribute('target', '_blank')
+          continueLink.addEventListener("click", handleClickContinueLink);
         }
 
         instance = new Fancybox([{ src: "modal" }], {
@@ -86,6 +98,10 @@
           on: {
             close: () => {
               continueButton.removeEventListener('click', handleClickContinue)
+              if(continueLink) {
+                continueLink.removeEventListener("click", handleClickContinueLink)
+              }
+              modalText.style.removeProperty('display')
             },
           },
         });
@@ -95,6 +111,12 @@
             instance.close();
           }, 500);
           return;
+        }
+
+        function handleClickContinueLink (event) {
+          setTimeout(() => {
+            instance.close();
+          }, 500);
         }
       });
     });


### PR DESCRIPTION
Fix hide/show text depends on external-link url

Includes:
- Uncomment content in div with modal__text classname and add closing tag for paragraph
![image](https://github.com/HackMort/strensiq-hcp/assets/5392981/597bc437-d2e8-4da6-8ca3-6f721c5c1ae9)

- Add array to know in which links the content of .modal__text has to be hidden
![image](https://github.com/HackMort/strensiq-hcp/assets/5392981/e285af31-20cc-43f6-ab51-6ef121b34ef5)

- Add variable that gets the container and set its display to none when URL is in array
![image](https://github.com/HackMort/strensiq-hcp/assets/5392981/68f66a5b-f280-465b-a48c-5aeb850a838a)

- Remove display from .modal__text when the modal is closed and remove event listener for click event in continue link if exists
![image](https://github.com/HackMort/strensiq-hcp/assets/5392981/7026fab2-aa5e-4ff8-9c38-1313f3ca2dc6)

- Add attributes href and target to continueLink if exists and change anonymous function to avoid multiple popups 
![image](https://github.com/HackMort/strensiq-hcp/assets/5392981/c92b3a25-8f36-48b5-82c9-bf8400fbec7d)
![image](https://github.com/HackMort/strensiq-hcp/assets/5392981/78b105e0-ab11-431f-85c9-93549cfae794)

