### PR TITLE
Fix/clinical data children texts

### DIFF
--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -1225,6 +1225,16 @@
                 }
             }
 
+            .table__footer {
+                sup {
+                    left: 3px;
+                }
+
+                span {
+                    text-indent: -3px;
+                }
+            }
+
             td,
             th {
                 text-align: left;

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -5951,6 +5951,12 @@ aqui
 
         }
 
+        @media screen and (min-width: 1024px) {
+            &:first-of-type {
+                max-width: 49ch;
+            }
+        }
+
         @include media('desktop') {
             font-size: 18px;
             line-height: 1.6875rem;
@@ -5958,9 +5964,6 @@ aqui
             max-width: 53ch;
             height: auto;
 
-            &:first-of-type {
-                max-width: 52ch;
-            }
         }
     }
 
@@ -6783,7 +6786,7 @@ aqui
 
             .cdchildren-container {
                 &__title {
-                    max-width: 35ch;
+                    max-width: 34ch;
                 }
 
                 &__footnote {


### PR DESCRIPTION
Includes: 
- Avoid line break in title and hihglighted text of Clinical Data - Children page
![image](https://github.com/HackMort/strensiq-hcp/assets/5392981/96c2714b-166c-498e-a0be-dad921919ad9)

- Reduce space between sup tag and text of footnote in table of Clinical Data - adults page
- Fix indent of footnote in table of Clinical Data - adults page
![image](https://github.com/HackMort/strensiq-hcp/assets/5392981/187616a4-a631-42cb-8246-cb1adc61fa79)